### PR TITLE
Move keypair attach/detach from Service to HostName, HostName bug fixes

### DIFF
--- a/lib/hosts.go
+++ b/lib/hosts.go
@@ -75,6 +75,16 @@ func (r *HostNameResource) List(instanceURL *string) ([]*HostName, error) {
 	return res, nil
 }
 
+func (r *HostNameResource) Update(hostName HostName) error {
+	u, _ := url.Parse(*hostName.URL)
+	hostName.URL = nil
+	_, err := r.client.Patch(u, &hostName, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r *HostNameResource) Delete(hostName *HostName) error {
 	hostNames, err := r.List(hostName.Instance)
 	if err != nil {

--- a/lib/hosts.go
+++ b/lib/hosts.go
@@ -86,20 +86,9 @@ func (r *HostNameResource) Update(hostName HostName) error {
 	return nil
 }
 
-func (r *HostNameResource) Delete(hostName *HostName) error {
-	hostNames, err := r.List(hostName.Instance)
-	if err != nil {
-		return err
-	}
-	var foundHostName *HostName
-	for i := range hostNames {
-		foundHostName = hostNames[i]
-		if hostName.Host == foundHostName.Host {
-			break
-		}
-	}
-	u, _ := url.Parse(*foundHostName.URL)
-	_, err = r.client.Delete(u, nil)
+func (r *HostNameResource) Delete(hostNameURL string) error {
+	u, _ := url.Parse(hostNameURL)
+	_, err := r.client.Delete(u, nil)
 	if err != nil {
 		return err
 	}

--- a/lib/hosts.go
+++ b/lib/hosts.go
@@ -12,6 +12,7 @@ type HostNameResource struct {
 type HostName struct {
 	Instance *string `json:"instance,omitempty"`
 	Host     *string `json:"host,omitempty"`
+	KeyPair  *string `json:"keypair,omitempty"`
 
 	URL *string `json:"url,omitempty"`
 
@@ -99,6 +100,18 @@ func (r *HostNameResource) Delete(hostName *HostName) error {
 	}
 	u, _ := url.Parse(*foundHostName.URL)
 	_, err = r.client.Delete(u, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (host *HostName) DetachKeyPair() error {
+	payload := struct {
+		KeyPair *KeyPair `json:"keypair"`
+	}{}
+	u, _ := url.Parse(*host.URL)
+	_, err := host.r.client.Patch(u, &payload, nil)
 	if err != nil {
 		return err
 	}

--- a/lib/services.go
+++ b/lib/services.go
@@ -19,7 +19,6 @@ type Service struct {
 	Replicas *int              `json:"replicas,omitempty"`
 	State    *string           `json:"state,omitempty"`
 	Env      map[string]string `json:"env,omitempty"`
-	KeyPair  *string           `json:"keypair,omitempty"`
 	WebURL   *string           `json:"web_url,omitempty"`
 
 	// create only
@@ -132,18 +131,6 @@ func (s *Service) SetReplicas(n int) error {
 	}
 	u, _ := url.Parse(*s.URL)
 	_, err := s.r.client.Patch(u, &desiredService, nil)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *Service) DetachKeyPair() error {
-	payload := struct {
-		KeyPair *KeyPair `json:"keypair"`
-	}{}
-	u, _ := url.Parse(*s.URL)
-	_, err := s.r.client.Patch(u, &payload, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- attach/detach `Keypair` at `HostName`
- Add `Get`, `List` and `Delete` to `HostNameResource` (requires [eldarion-gondor/api#10](https://github.com/eldarion-gondor/api/pull/10))
- Fixes a bug where the wrong hostname could be deleted
